### PR TITLE
Possibly fix `Vec2` rotation arithmetic signs

### DIFF
--- a/src/rotor.rs
+++ b/src/rotor.rs
@@ -193,11 +193,11 @@ macro_rules! rotor2s {
             /// `self` *must* be normalized!
             #[inline]
             pub fn rotate_vec(self, vec: &mut $vt) {
-                let fx = self.s * vec.x + self.bv.xy * vec.y;
-                let fy = self.s * vec.y - (self.bv.xy * vec.x);
+                let fx = self.s * vec.x - self.bv.xy * vec.y;
+                let fy = self.s * vec.y + (self.bv.xy * vec.x);
 
-                vec.x = self.s * fx + self.bv.xy * fy;
-                vec.y = self.s * fy - (self.bv.xy * fx);
+                vec.x = self.s * fx - self.bv.xy * fy;
+                vec.y = self.s * fy + (self.bv.xy * fx);
             }
 
             #[inline]


### PR DESCRIPTION
Deny if I have the wrong idea, but I think this should fix the error I was getting using version 0.6. Do note that 0.6 uses different lines entirely, but the repo seems to have the more correct code.