### PR TITLE
Fix slurp not always taking shortest path

### DIFF
--- a/src/interp.rs
+++ b/src/interp.rs
@@ -80,9 +80,8 @@ macro_rules! impl_slerp_rotor3 {
             ///
             /// Note that you should often normalize the result returned by this operation, when working with `Rotor`s, etc!
             #[inline]
-            fn slerp(&self, end: Self, t: $tt) -> Self {
+            fn slerp(&self, mut end: Self, t: $tt) -> Self {
                 let mut dot = self.dot(end);
-                let mut end = end.clone();
 
                 // make sure interpolation takes shortest path in case dot product is negative
                 if dot < 0.0 {

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -81,7 +81,14 @@ macro_rules! impl_slerp_rotor3 {
             /// Note that you should often normalize the result returned by this operation, when working with `Rotor`s, etc!
             #[inline]
             fn slerp(&self, end: Self, t: $tt) -> Self {
-                let dot = self.dot(end);
+                let mut dot = self.dot(end);
+                let mut end = end.clone();
+
+                // make sure interpolation takes shortest path in case dot product is negative
+                if dot < 0.0 {
+                    end = end * -1.0;
+                    dot = -dot;
+                }
 
                 if dot > 0.9995 {
                     return self.lerp(end, t);


### PR DESCRIPTION
Fixes issue #152. As discussed in this issue and explained [here](https://github.com/KhronosGroup/glTF/issues/1395#issuecomment-933008176), most 3d engines (and model exporters) expect slerp between two quaternions (rotors in this case) to always take shortest path, despite dot product's sign.
Fixes an issue when interpolating between keyframes of animated models.