### PR TITLE
Added support for `num_traits::identities`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 <!-- next-header -->
 ## Unreleased
 
+- Add `num_traits::identities` support behind a `num-traits` feature flag
+
 ## 0.9.1
 
 - Fix `from_euler_angles` on `Mat4`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ wide = { version = "0.7" }
 serde = { version = "1.0", features = [], optional = true }
 mint = { version = "0.5", optional = true }
 bytemuck = { version = "1.4", optional = true }
+num-traits = { version = "0.2.15", optional = true }
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ ultraviolet = { version = "0.9", features = [ "f64", "int" ] }
 
 Will enable the `f64` and `int` features. Here's a list of the available features:
 
-* `f64` - Enable f64 bit wide floating point support. Naming convention is `D[Type]`, such as `DVec3x4` would be a collection of 4 3d vectors with f64 precision each.
-* `int` - Enable integer vector types.
-* `serde` - Enable Serialize and Deserialize implementations for many scalar types.
-* `mint` - Enable interoperation with other math libraries through the `mint` interface
-* `bytemuck` - Enable casting of many types to byte arrays, for use with graphics APIs.
+* `f64` – Enable `f64` bit wide floating point support. Naming convention is `D[Type]`, such as `DVec3x4` would be a collection of 4 3d vectors with `f64` precision each.
+* `int` – Enable integer vector types.
+* `bytemuck` – Enable casting of many types to byte arrays, for use with graphics APIs.
+* `mint` – Enable interoperation with other math crates through the `mint` interface.
+* `num-traits` – Enable [identity traits](https://docs.rs/num-traits/latest/num_traits/identities/index.html) for interoperation with other math crates.
+* `serde` – Enable `Serialize` and `Deserialize` implementations for many scalar types.
 
 ## Crate Features
 

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -85,7 +85,7 @@ macro_rules! impl_slerp_rotor3 {
 
                 // make sure interpolation takes shortest path in case dot product is negative
                 if dot < 0.0 {
-                    end = end * -1.0;
+                    end *= -1.0;
                     dot = -dot;
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,10 +42,12 @@
 //!
 //! Will enable the `f64` and `int` features. Here's a list of the available features:
 //!
-//! * `f64` - Enable f64 bit wide floating point support. Naming convention is `D[Type]`, such as `DVec3x4` would be a collection of 4 3d vectors with f64 precision each.
-//! * `int` - Enable integer vector types.
-//! * `serde` - Enable Serialize and Deserialize implementations for many scalar types.
-//! * `mint` - Enable interoperation with other math libraries through the `mint` interface
+//! * `f64` – Enable `f64` bit wide floating point support. Naming convention is `D[Type]`, such as `DVec3x4` would be a collection of 4 3d vectors with `f64` precision each.
+//! * `int` – Enable integer vector types.
+//! * `bytemuck` – Enable casting of many types to byte arrays, for use with graphics APIs.
+//! * `mint` – Enable interoperation with other math crates through the `mint` interface.
+//! * `num-traits` – Enable [identity traits](https://docs.rs/num-traits/latest/num_traits/identities/index.html) for interoperation with other math crates.
+//! * `serde` – Enable `Serialize` and `Deserialize` implementations for many scalar types.
 //!
 //! ## Crate Features
 //!

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -3,6 +3,12 @@ mod vec2;
 mod vec3;
 mod vec4;
 
+#[cfg(feature = "num-traits")]
+mod num_traits;
+
 pub use vec2::*;
 pub use vec3::*;
 pub use vec4::*;
+
+#[cfg(feature = "num-traits")]
+pub use ::num_traits::*;

--- a/src/vec/num_traits.rs
+++ b/src/vec/num_traits.rs
@@ -1,0 +1,31 @@
+use crate::*;
+
+macro_rules! impl_num_traits_vecs {
+    ($($n:ident),+) => {
+        $(
+        impl num_traits::Zero for $n {
+            #[inline]
+            fn zero() -> Self {
+                $n::zero()
+            }
+
+            #[inline]
+            fn is_zero(&self) -> bool {
+                &$n::zero() == self
+            }
+        }
+
+        impl num_traits::One for $n {
+            #[inline]
+            fn one() -> Self {
+                $n::one()
+            }
+        }
+        )+
+    };
+}
+
+impl_num_traits_vecs!(Vec2, Vec2x4, Vec2x8, Vec3, Vec3x4, Vec3x8, Vec4, Vec4x4, Vec4x8);
+
+#[cfg(feature = "f64")]
+impl_num_traits_vecs!(DVec2, DVec2x2, DVec2x4, DVec3, DVec3x2, DVec3x4, DVec4, DVec4x2, DVec4x4);


### PR DESCRIPTION
This is for #157.

* The `impl`s are in `src/vec/num_traits.rs`.
* This is behind a resp. feature flag documented in `src/lib.rs` and `README.md`.
* I took the liberty to reorder the features alphabetically (except `f64` & `int` as these are probably what people look for most).
* `clippy` clean.

I noticed three `serde` tests are failing when `cargo test --all-features` is ran but they did so before my changes:
```
test impl_serde::mat_serde_tests::mat2 ... FAILED
test impl_serde::mat_serde_tests::mat3 ... FAILED
test impl_serde::mat_serde_tests::mat4 ... FAILED
```
