### PR TITLE
Account for scale in Similarity inverse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Unreleased
 
 - Add `num_traits::identities` support behind a `num-traits` feature flag
+- Fix inverse for similarities
 
 ## 0.9.1
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -313,8 +313,8 @@ macro_rules! similarities {
             #[inline]
             pub fn inverse(&mut self) {
                 self.rotation.reverse();
-                self.translation = self.rotation * (-self.translation);
                 self.scale = $t::splat(1.0) / self.scale;
+                self.translation = self.rotation * (-self.translation) * self.scale;
             }
 
             #[inline]


### PR DESCRIPTION
Hey, many thanks for sharing this crate, it is super useful!

I was just hunting down some odd transform behaviour, and I think the root cause is the `Similarity` inverse not handling scale correctly (specifically when inverting the translation part).

This PR has my local fix, which resolves my issue locally. If you wouldn't mind taking a look for the next update then that would be great, thanks!