### PR TITLE
Fix missing mut in Mat4::as_mut_array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Add `num_traits::identities` support behind a `num-traits` feature flag
 - Fix inverse for similarities
+- Fix missing `mut` in `Mat4::as_mut_array` result
 
 ## 0.9.1
 

--- a/src/mat.rs
+++ b/src/mat.rs
@@ -1523,7 +1523,7 @@ macro_rules! mat4s {
 
             /// Interpret `self` as a statically sized array of the base numeric type.
             #[inline]
-            pub fn as_mut_array(&mut self) -> &[$t; 16] {
+            pub fn as_mut_array(&mut self) -> &mut [$t; 16] {
                 let ptr = self as *mut $n as *mut [$t; 16];
                 unsafe { &mut *ptr }
             }


### PR DESCRIPTION
Hello again, this is a typo fix to make the output of `Mat4::as_mut_array` mutatable, to match the other matrix sizes.

If you have time to take a look for the next update then that would be awesome, thanks!