### PR TITLE
Add missing mint type conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Update `projection` module's and submodules' documentation
 - Remove `rh_ydown` projection module as it was very unlikely to be useful and caused confusion.
+- Add `mint` type conversions for integer vectors
 
 ## 0.9.2
 

--- a/src/impl_mint.rs
+++ b/src/impl_mint.rs
@@ -68,7 +68,11 @@ macro_rules! from_vec4s {
 
 from_vec2s!(
     mint::Vector2<f32> => Vec2,
-    mint::Point2<f32> => Vec2
+    mint::Point2<f32> => Vec2,
+    mint::Vector2<i32> => IVec2,
+    mint::Point2<i32> => IVec2,
+    mint::Vector2<u32> => UVec2,
+    mint::Point2<u32> => UVec2
 );
 #[cfg(feature = "f64")]
 from_vec2s!(
@@ -78,7 +82,11 @@ from_vec2s!(
 
 from_vec3s!(
     mint::Vector3<f32> => Vec3,
-    mint::Point3<f32> => Vec3
+    mint::Point3<f32> => Vec3,
+    mint::Vector3<i32> => IVec3,
+    mint::Point3<i32> => IVec3,
+    mint::Vector3<u32> => UVec3,
+    mint::Point3<u32> => UVec3
 );
 #[cfg(feature = "f64")]
 from_vec3s!(
@@ -86,9 +94,15 @@ from_vec3s!(
     mint::Point3<f64> => DVec3
 );
 
-from_vec4s!(mint::Vector4<f32> => Vec4);
+from_vec4s!(
+    mint::Vector4<f32> => Vec4,
+    mint::Vector4<i32> => IVec4,
+    mint::Vector4<u32> => UVec4
+);
 #[cfg(feature = "f64")]
-from_vec4s!(mint::Vector4<f64> => DVec4);
+from_vec4s!(
+    mint::Vector4<f64> => DVec4
+);
 
 macro_rules! from_mat2s {
     ($($minttype:ty => $uvtype:ty),+) => {


### PR DESCRIPTION
We're planning to use ultraviolet together with https://github.com/LPGhatguy/crevice (turns Rusty structs into structs that the GPU understands).

This adds more mint types to Ultraviolet, which will then make it possible to add really nice ultraviolet support to crevice.