### PR TITLE
Fix enabling mint without int

### DIFF
--- a/src/impl_mint.rs
+++ b/src/impl_mint.rs
@@ -68,7 +68,10 @@ macro_rules! from_vec4s {
 
 from_vec2s!(
     mint::Vector2<f32> => Vec2,
-    mint::Point2<f32> => Vec2,
+    mint::Point2<f32> => Vec2
+);
+#[cfg(feature = "int")]
+from_vec2s!(
     mint::Vector2<i32> => IVec2,
     mint::Point2<i32> => IVec2,
     mint::Vector2<u32> => UVec2,
@@ -82,7 +85,10 @@ from_vec2s!(
 
 from_vec3s!(
     mint::Vector3<f32> => Vec3,
-    mint::Point3<f32> => Vec3,
+    mint::Point3<f32> => Vec3
+);
+#[cfg(feature = "int")]
+from_vec3s!(
     mint::Vector3<i32> => IVec3,
     mint::Point3<i32> => IVec3,
     mint::Vector3<u32> => UVec3,
@@ -95,7 +101,10 @@ from_vec3s!(
 );
 
 from_vec4s!(
-    mint::Vector4<f32> => Vec4,
+    mint::Vector4<f32> => Vec4
+);
+#[cfg(feature = "int")]
+from_vec4s!(
     mint::Vector4<i32> => IVec4,
     mint::Vector4<u32> => UVec4
 );


### PR DESCRIPTION
This PR fixes a minor issue in #163 where `mint` conversions are added for integer types, but without checking that the `int` feature is enabled.

This leads to compile errors if `mint` is enabled without `int`.  With the changes in this PR, the two features can be enabled independently again (tested in a local project that only enables `mint`).

(No changelog entry since there has not yet been a release with these additional conversions.)