### PR TITLE
Add mint quaternion support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add `mint` type conversions for integer vectors
 - Implement Serialize and Deserialize for `Similarity`
 - Implement Serialize and Deserialize for f64 types: `DBivec`, `DRotor`, `DIsometry`, `DSimilarity`
+- Add type conversion between `mint` quaternion and `Rotor3`
 
 ## 0.9.2
 

--- a/src/impl_mint.rs
+++ b/src/impl_mint.rs
@@ -219,4 +219,4 @@ macro_rules! from_quat {
 
 from_quat!(mint::Quaternion<f32> => Rotor3);
 #[cfg(feature = "f64")]
-from_mat4s!(mint::Quaternion<f64> => DRotor3);
+from_quat!(mint::Quaternion<f64> => DRotor3);

--- a/src/impl_mint.rs
+++ b/src/impl_mint.rs
@@ -190,3 +190,33 @@ from_mat3s!(mint::ColumnMatrix3<f64> => DMat3);
 from_mat4s!(mint::ColumnMatrix4<f32> => Mat4);
 #[cfg(feature = "f64")]
 from_mat4s!(mint::ColumnMatrix4<f64> => DMat4);
+
+macro_rules! from_quat {
+    ($($minttype:ty => $uvtype:ty),+) => {
+        $(impl From<$minttype> for $uvtype {
+            #[inline]
+            fn from(q: $minttype) -> Self {
+                Self::from_quaternion_array([q.v.x, q.v.y, q.v.z, q.s])
+            }
+        }
+
+        impl From<$uvtype> for $minttype {
+            #[inline]
+            fn from(r: $uvtype) -> Self {
+                let arr = r.into_quaternion_array();
+                Self {
+                    v: mint::Vector3 {
+                        x: arr[0],
+                        y: arr[1],
+                        z: arr[2],
+                    },
+                    s: arr[3],
+                }
+            }
+        })+
+    }
+}
+
+from_quat!(mint::Quaternion<f32> => Rotor3);
+#[cfg(feature = "f64")]
+from_mat4s!(mint::Quaternion<f64> => DRotor3);


### PR DESCRIPTION
This PR adds conversion between `mint::Quaternion` and `Rotor3` types, implemented using the existing functions `Rotor3::from_quaternion_array` and `Rotor3::into_quaternion_array`.

Tested locally in a project that uses `glam`, rotations seem to round-trip ok!  If this PR could be considered for a future update that would be great, thanks! :)